### PR TITLE
Update Action Creators to import AppDispatcher instance

### DIFF
--- a/scripts/actions/RepoActionCreators.js
+++ b/scripts/actions/RepoActionCreators.js
@@ -1,4 +1,4 @@
-import { dispatchAsync } from '../AppDispatcher';
+import AppDispatcher from '../AppDispatcher';
 import ActionTypes from '../constants/ActionTypes';
 import * as RepoAPI from '../api/RepoAPI';
 import StarredReposByUserStore from '../stores/StarredReposByUserStore';
@@ -10,7 +10,7 @@ export function requestRepo(fullName, fields) {
     return;
   }
 
-  dispatchAsync(RepoAPI.getRepo(fullName), {
+  AppDispatcher.dispatchAsync(RepoAPI.getRepo(fullName), {
     request: ActionTypes.REQUEST_REPO,
     success: ActionTypes.REQUEST_REPO_SUCCESS,
     failure: ActionTypes.REQUEST_REPO_ERROR
@@ -31,7 +31,7 @@ export function requestStarredReposPage(login, isInitialRequest) {
   }
 
   const nextPageUrl = StarredReposByUserStore.getNextPageUrl(login);
-  dispatchAsync(RepoAPI.getStarredReposPage(login, nextPageUrl), {
+  AppDispatcher.dispatchAsync(RepoAPI.getStarredReposPage(login, nextPageUrl), {
     request: ActionTypes.REQUEST_STARRED_REPOS_PAGE,
     success: ActionTypes.REQUEST_STARRED_REPOS_PAGE_SUCCESS,
     failure: ActionTypes.REQUEST_STARRED_REPOS_PAGE_ERROR

--- a/scripts/actions/UserActionCreators.js
+++ b/scripts/actions/UserActionCreators.js
@@ -1,4 +1,4 @@
-import { dispatchAsync } from '../AppDispatcher';
+import AppDispatcher from '../AppDispatcher';
 import ActionTypes from '../constants/ActionTypes';
 import * as UserAPI from '../api/UserAPI';
 import UserStore from '../stores/UserStore';
@@ -10,7 +10,7 @@ export function requestUser(login, fields) {
     return;
   }
 
-  dispatchAsync(UserAPI.getUser(login), {
+  AppDispatcher.dispatchAsync(UserAPI.getUser(login), {
     request: ActionTypes.REQUEST_USER,
     success: ActionTypes.REQUEST_USER_SUCCESS,
     failure: ActionTypes.REQUEST_USER_ERROR
@@ -31,7 +31,7 @@ export function requestStargazerPage(fullName, isInitialRequest) {
   }
 
   const nextPageUrl = StargazersByRepoStore.getNextPageUrl(fullName);
-  dispatchAsync(UserAPI.getStargazerPage(fullName, nextPageUrl), {
+  AppDispatcher.dispatchAsync(UserAPI.getStargazerPage(fullName, nextPageUrl), {
     request: ActionTypes.REQUEST_STARGAZER_PAGE,
     success: ActionTypes.REQUEST_STARGAZER_PAGE_SUCCESS,
     failure: ActionTypes.REQUEST_STARGAZER_PAGE_ERROR


### PR DESCRIPTION
I get the error `Uncaught TypeError: Cannot read property 'dispatch' of undefined` when cloning and running this repo.

Calling `dispatchAsync` directly instead of `AppDispatcher.dispatchAsync` means `this` is undefined in `dispatchAsync`, so this fails `this.dispatch(request, action);`